### PR TITLE
Full Implementation of AWF and removing of KMP_MIN environment variable

### DIFF
--- a/runtime/src/kmp.h
+++ b/runtime/src/kmp.h
@@ -350,6 +350,7 @@ typedef enum kmp_sched {
   kmp_sched_af = 115, // mapped to kmp_sch_af (60)
   kmp_sched_af_a = 116, // mapped to kmp_sch_af_a (61)
   kmp_sched_profiling = 117, // mapped to kmp_sch_profiling (62)
+  kmp_sched_awf = 118, // mapped to kmp_sch_awf (63)
   //--------------LB4OMP_extensions----------------
   kmp_sched_upper,
   kmp_sched_default = kmp_sched_static // default scheduling
@@ -402,6 +403,7 @@ enum sched_type : kmp_int32 {
   kmp_sch_af = 60,
   kmp_sch_af_a = 61,
   kmp_sch_profiling = 62,
+  kmp_sch_awf = 63,
   //--------------LB4OMP_extensions----------------
 
   /* accessible only through KMP_SCHEDULE environment variable */
@@ -3085,7 +3087,7 @@ extern enum sched_type __kmp_auto; /* default auto scheduling method */
 extern int __kmp_chunk; /* default runtime chunk size */
 
 //------------------LB4OMP_extensions----------------------
-extern int __kmp_env_min; /* minimum chunk size (default = 0/off) */
+//extern int __kmp_env_min; /* minimum chunk size (default = 0/off) */
 extern int __kmp_env_mu; /* mean value of iteration times [micro s] */
 extern double __kmp_env_sigma; /* sd of iteration times [micro s] */
 extern int __kmp_env_overhead; /* scheduling overhead time [micro s] */

--- a/runtime/src/kmp_dispatch.cpp
+++ b/runtime/src/kmp_dispatch.cpp
@@ -1190,8 +1190,16 @@ LOOP_TIME_MEASURE_START
             std::vector<int> sWS(nproc, 0);
             std::vector<double> eT(nproc,0.0);
             std::vector<double> sET(nproc, 0.0);
-            std::vector<double> w(nproc, 1.0);
- 
+            std::vector<double> w;
+            //check initial weights
+            if (__kmp_env_weights.size() == nproc)
+            { w =  __kmp_env_weights;}
+            else
+            { 
+               std::vector<double> defaultweights(nproc, 1.0);
+               w = defaultweights;
+            }
+
             //set a new loop record and set autoSearch to 1
             AWFDataRecord data = 
             {
@@ -3532,6 +3540,8 @@ if((int)tid == 0){
           AWFCounter = 0; //reset flag
 
 
+         // printf("[AWF] status == 0, step %d,  thread %d, weight %lf, time %lf\n", AWFData.at(cLoopName).timeStep,tid, AWFData.at(cLoopName).weights[tid],  AWFData.at(cLoopName).executionTimes[tid]);
+
           double awap = 0.0;
 
           for(T i=0; i< nproc; i++)
@@ -3553,7 +3563,7 @@ if((int)tid == 0){
           //  printf("%d, %lf \n", i, AWFData.at(cLoopName).weights[i]);
           }
              
-          //printf("[AWF] status == 0, step %d,  thread %d, weight %lf, time %lf\n", AWFData.at(cLoopName).timeStep,tid, AWFData.at(cLoopName).weights[tid],  AWFData.at(cLoopName).executionTimes[tid]);
+         // printf("[AWF] status == 0, step %d,  thread %d, weight %lf, time %lf\n", AWFData.at(cLoopName).timeStep,tid, AWFData.at(cLoopName).weights[tid],  AWFData.at(cLoopName).executionTimes[tid]);
        }
       *p_lb = 0;
       *p_ub = 0;

--- a/runtime/src/kmp_global.cpp
+++ b/runtime/src/kmp_global.cpp
@@ -242,7 +242,8 @@ enum sched_type __kmp_sch_map[kmp_sched_upper - kmp_sched_lower_ext +
     kmp_sch_awf_e, // ==> kmp_sch_awf_e          = 114
     kmp_sch_af, // ==> kmp_sch_af          = 115
     kmp_sch_af_a, // ==> kmp_sch_af_a          = 116
-    kmp_sch_profiling // ==> kmp_sch_profiling          = 117
+    kmp_sch_profiling, // ==> kmp_sch_profiling          = 117
+    kmp_sch_awf // ==> kmp_sch_awf          = 118
     //--------------LB4OMP_extensions----------------
     // will likely not be used, introduced here just to debug the code
     // of public intel extension schedules
@@ -558,7 +559,7 @@ kmp_target_offload_kind_t __kmp_target_offload = tgt_default;
 
 //----------------------LB4OMP_extensions----------------------
 /* For additional dynamic scheduling techniques */
-int __kmp_env_min = 0; /* minimum chunk size (default = 0/off) */
+//int __kmp_env_min = 0; /* minimum chunk size (default = 0/off) */
 int __kmp_env_mu = 1600; /* mean value of iteration times [micro s] */
 double __kmp_env_sigma = 30; /* sd of iteration times [micro s] */
 int __kmp_env_overhead = 1000; /* scheduling overhead time [micro s] */

--- a/runtime/src/kmp_runtime.cpp
+++ b/runtime/src/kmp_runtime.cpp
@@ -2928,6 +2928,9 @@ void __kmp_get_schedule(int gtid, kmp_sched_t *kind, int *chunk) {
   case kmp_sch_profiling:
     *kind = kmp_sched_profiling;
     break;
+  case kmp_sch_awf:
+    *kind = kmp_sched_awf;
+    break;
     //----------------LB4OMP_extensions-------------------
 #if KMP_STATIC_STEAL_ENABLED
   case kmp_sch_static_steal:

--- a/runtime/src/kmp_settings.cpp
+++ b/runtime/src/kmp_settings.cpp
@@ -3731,6 +3731,8 @@ static const char *__kmp_parse_single_omp_schedule(const char *name,
     sched = kmp_sch_af_a;
   else if (!__kmp_strcasecmp_with_sentinel("profiling", ptr, *delim)) /* P */
     sched = kmp_sch_profiling;
+  else if (!__kmp_strcasecmp_with_sentinel("awf", ptr, *delim)) /* AWF */
+    sched = kmp_sch_awf;
     //--------------------LB4OMP_extensions--------------------------
 #if KMP_STATIC_STEAL_ENABLED
   else if (!__kmp_strcasecmp_with_sentinel("static_steal", ptr, *delim))
@@ -3881,6 +3883,9 @@ static void __kmp_stg_print_omp_schedule(kmp_str_buf_t *buffer,
       break;
     case kmp_sch_profiling:
       __kmp_str_buf_print(buffer, "%s,%d'\n", "profiling", __kmp_chunk);
+      break;
+    case kmp_sch_awf:
+      __kmp_str_buf_print(buffer, "%s,%d'\n", "awf", __kmp_chunk);
       break;
       //---------------LB4OMP_extensions----------------------
     case kmp_sch_static:
@@ -4833,7 +4838,7 @@ static void __kmp_stg_print_omp_tool_libraries(kmp_str_buf_t *buffer,
 } // __kmp_stg_print_omp_tool_libraries
 
 //-------------------------LB4OMP_extensions----------------------------
-
+/*
 static void __kmp_stg_parse_env_min(char const *name, char const *value,
                                    void *data) {
   __kmp_stg_parse_int(name, value, 0, INT_MAX, &__kmp_env_min);
@@ -4843,6 +4848,7 @@ static void __kmp_stg_print_env_min(kmp_str_buf_t *buffer, char const *name,
                                    void *data) {
   __kmp_stg_print_int(buffer, name, __kmp_env_min);
 } // __kmp_stg_print_env_min
+*/
 
 static void __kmp_stg_parse_env_mu(char const *name, char const *value,
                                    void *data) {
@@ -5209,7 +5215,7 @@ static kmp_setting_t __kmp_stg_table[] = {
 #endif
 
     //------------------LB4OMP_extensions------------------
-    {"KMP_MIN", __kmp_stg_parse_env_min, __kmp_stg_print_env_min, NULL, 0, 0},
+   // {"KMP_MIN", __kmp_stg_parse_env_min, __kmp_stg_print_env_min, NULL, 0, 0},
     {"KMP_MU", __kmp_stg_parse_env_mu, __kmp_stg_print_env_mu, NULL, 0, 0},
     {"KMP_SIGMA", __kmp_stg_parse_env_sigma, __kmp_stg_print_env_sigma, NULL, 0,
      0},


### PR DESCRIPTION
Full Implementation of AWF for time-stepping applications.
Also, extended DLS techniques now read minimum chunk sizes similar to standard techniques, i.e. technique name, chunk size.
Therefore, KMP_MIN is also removed as it is a redundant method.